### PR TITLE
Common session interceptor for okhttp3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 subprojects {
     group 'org.ccci.gto.android'
-    version '0.8.1-SNAPSHOT'
+    version '0.9.0-SNAPSHOT'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ buildscript {
 }
 
 subprojects {
+    apply plugin: 'com.android.library'
+
     group 'org.ccci.gto.android'
     version '0.9.0-SNAPSHOT'
 
@@ -26,7 +28,7 @@ subprojects {
         }
     }
 
-    afterEvaluate {
+    beforeEvaluate {
         android {
             compileSdkVersion 23
             buildToolsVersion "23.0.1"

--- a/gto-support-api-base/build.gradle
+++ b/gto-support-api-base/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'com.android.library'
+
+dependencies {
+    compile project(':gto-support-core')
+}

--- a/gto-support-api-base/build.gradle
+++ b/gto-support-api-base/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile project(':gto-support-core')
 }

--- a/gto-support-api-base/src/main/AndroidManifest.xml
+++ b/gto-support-api-base/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.ccci.gto.android.common.api.base"/>

--- a/gto-support-api-base/src/main/java/org/ccci/gto/android/common/api/Session.java
+++ b/gto-support-api-base/src/main/java/org/ccci/gto/android/common/api/Session.java
@@ -1,0 +1,67 @@
+package org.ccci.gto.android.common.api;
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+/**
+ * Object representing an individual session for this API. Can be extended to track additional session data.
+ */
+public class Session {
+    protected static final String PREF_SESSION_BASE_NAME = "session";
+
+    @NonNull
+    private final String mBaseAttrName;
+
+    @Nullable
+    public final String id;
+
+    public Session(@Nullable final String id) {
+        this(id, PREF_SESSION_BASE_NAME);
+    }
+
+    public Session(@Nullable final String id, @Nullable final String baseAttrName) {
+        mBaseAttrName = baseAttrName != null ? baseAttrName : PREF_SESSION_BASE_NAME;
+        this.id = id;
+    }
+
+    public Session(@NonNull final SharedPreferences prefs) {
+        this(prefs, null);
+    }
+
+    public Session(@NonNull final SharedPreferences prefs, @Nullable final String baseAttrName) {
+        mBaseAttrName = baseAttrName != null ? baseAttrName : PREF_SESSION_BASE_NAME;
+        this.id = prefs.getString(getPrefAttrName("id"), null);
+    }
+
+    public boolean isValid() {
+        return this.id != null;
+    }
+
+    @NonNull
+    public final String getPrefAttrName(@NonNull final String type) {
+        return mBaseAttrName + "." + type;
+    }
+
+    public void save(@NonNull final SharedPreferences.Editor prefs) {
+        prefs.putString(getPrefAttrName("id"), this.id);
+    }
+
+    public void delete(@NonNull final SharedPreferences.Editor prefs) {
+        prefs.remove(getPrefAttrName("id"));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Session that = (Session) o;
+        return TextUtils.equals(id, that.id);
+    }
+}

--- a/gto-support-api-base/src/main/java/org/ccci/gto/android/common/api/TheKeySession.java
+++ b/gto-support-api-base/src/main/java/org/ccci/gto/android/common/api/TheKeySession.java
@@ -1,0 +1,50 @@
+package org.ccci.gto.android.common.api;
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import java.util.Locale;
+
+public class TheKeySession extends Session {
+    @Nullable
+    private final String mGuid;
+
+    public TheKeySession(@Nullable final String id, @Nullable final String guid) {
+        this(id, guid, PREF_SESSION_BASE_NAME);
+    }
+
+    public TheKeySession(@Nullable final String id, @Nullable final String guid, @NonNull final String baseAttrName) {
+        super(id, (guid != null ? guid.toUpperCase(Locale.US) + "." : "") + baseAttrName);
+        mGuid = guid != null ? guid.toUpperCase(Locale.US) : null;
+    }
+
+    public TheKeySession(@NonNull final SharedPreferences prefs, @Nullable final String guid) {
+        this(prefs, guid, PREF_SESSION_BASE_NAME);
+    }
+
+    public TheKeySession(@NonNull final SharedPreferences prefs, @Nullable final String guid,
+                         @NonNull final String baseAttrName) {
+        super(prefs, (guid != null ? guid.toUpperCase(Locale.US) + "." : "") + baseAttrName);
+        mGuid = guid != null ? guid.toUpperCase(Locale.US) : null;
+    }
+
+    @Override
+    public boolean isValid() {
+        return super.isValid() && mGuid != null;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final TheKeySession that = (TheKeySession) o;
+        return super.equals(o) && TextUtils.equals(mGuid, that.mGuid);
+    }
+}

--- a/gto-support-api-okhttp3/build.gradle
+++ b/gto-support-api-okhttp3/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'com.android.library'
+
+android {
+    defaultConfig {
+        minSdkVersion 9
+    }
+}
+
+dependencies {
+    compile project(':gto-support-api-base')
+
+    compile 'com.squareup.okhttp3:okhttp:3.2.0'
+}

--- a/gto-support-api-okhttp3/build.gradle
+++ b/gto-support-api-okhttp3/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 android {
     defaultConfig {
         minSdkVersion 9

--- a/gto-support-api-okhttp3/lint.xml
+++ b/gto-support-api-okhttp3/lint.xml
@@ -2,6 +2,5 @@
 <lint>
     <issue id="InvalidPackage">
         <ignore regexp="okio-([0-9]*\.?)*\.jar"/>
-        <ignore regexp="retrofit-([0-9]*\.?)*(-(beta[0-9]*))?\.jar"/>
     </issue>
 </lint>

--- a/gto-support-api-okhttp3/lint.xml
+++ b/gto-support-api-okhttp3/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore regexp="okio-([0-9]*\.?)*\.jar"/>
+        <ignore regexp="retrofit-([0-9]*\.?)*(-(beta[0-9]*))?\.jar"/>
+    </issue>
+</lint>

--- a/gto-support-api-okhttp3/src/main/AndroidManifest.xml
+++ b/gto-support-api-okhttp3/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.ccci.gto.android.common.api.okhttp3"/>

--- a/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/ApiException.java
+++ b/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/ApiException.java
@@ -1,0 +1,12 @@
+package org.ccci.gto.android.common.api.okhttp3;
+
+import java.io.IOException;
+
+public class ApiException extends IOException {
+    public ApiException() {
+    }
+
+    public ApiException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/InvalidSessionApiException.java
+++ b/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/InvalidSessionApiException.java
@@ -1,0 +1,10 @@
+package org.ccci.gto.android.common.api.okhttp3;
+
+public class InvalidSessionApiException extends ApiException {
+    public InvalidSessionApiException() {
+    }
+
+    public InvalidSessionApiException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptor.java
+++ b/gto-support-api-okhttp3/src/main/java/org/ccci/gto/android/common/api/okhttp3/interceptor/SessionInterceptor.java
@@ -1,0 +1,127 @@
+package org.ccci.gto.android.common.api.okhttp3.interceptor;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.ccci.gto.android.common.api.Session;
+import org.ccci.gto.android.common.api.okhttp3.InvalidSessionApiException;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public abstract class SessionInterceptor<S extends Session> implements Interceptor {
+    protected final Object LOCK_SESSION = new Object();
+
+    @NonNull
+    protected final Context mContext;
+    @NonNull
+    private final String mPrefFile;
+
+    protected SessionInterceptor(@NonNull final Context context) {
+        this(context, null);
+    }
+
+    protected SessionInterceptor(@NonNull final Context context, @Nullable final String prefFile) {
+        mContext = context.getApplicationContext();
+        mPrefFile = prefFile != null ? prefFile : getClass().getSimpleName();
+    }
+
+    @NonNull
+    protected final SharedPreferences getPrefs() {
+        return mContext.getSharedPreferences(mPrefFile, Context.MODE_PRIVATE);
+    }
+
+    @Override
+    public final Response intercept(@NonNull final Chain chain) throws IOException {
+        // get the session, establish a session if one doesn't exist or if we have a stale session
+        S session;
+        synchronized (LOCK_SESSION) {
+            session = loadSession();
+            if (session == null) {
+                session = establishSession();
+
+                // save the newly established session
+                if (session != null && session.isValid()) {
+                    saveSession(session);
+                }
+            }
+        }
+
+        // throw an exception if we don't have a valid session
+        if (session == null) {
+            throw new InvalidSessionApiException();
+        }
+
+        // process request
+        final Response response = chain.proceed(attachSession(chain.request(), session));
+
+        // make sure the response is valid
+        if (isSessionInvalid(response)) {
+            // reset the session
+            synchronized (LOCK_SESSION) {
+                // only reset if this is still the same session
+                final S active = loadSession();
+                if (active != null && active.equals(session)) {
+                    deleteSession(session);
+                }
+            }
+        }
+
+        return response;
+    }
+
+    @NonNull
+    protected abstract Request attachSession(@NonNull Request request, @NonNull S session);
+
+    protected boolean isSessionInvalid(@NonNull final Response response) throws IOException {
+        return false;
+    }
+
+    @Nullable
+    private S loadSession() {
+        // load a pre-existing session
+        final SharedPreferences prefs = this.getPrefs();
+        final S session;
+        synchronized (LOCK_SESSION) {
+            session = loadSession(prefs);
+        }
+
+        // only return valid sessions
+        return session != null && session.isValid() ? session : null;
+    }
+
+    @Nullable
+    protected abstract S loadSession(@NonNull SharedPreferences prefs);
+
+    @Nullable
+    protected S establishSession() throws IOException {
+        return null;
+    }
+
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+    private void saveSession(@NonNull final S session) {
+        final SharedPreferences.Editor prefs = this.getPrefs().edit();
+        session.save(prefs);
+
+        synchronized (LOCK_SESSION) {
+            prefs.apply();
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+    private void deleteSession(@NonNull final S session) {
+        final SharedPreferences.Editor prefs = getPrefs().edit();
+        session.delete(prefs);
+
+        synchronized (LOCK_SESSION) {
+            prefs.apply();
+        }
+    }
+}

--- a/gto-support-api/build.gradle
+++ b/gto-support-api/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile project(':gto-support-core')
     compile project(':gto-support-api-base')

--- a/gto-support-api/build.gradle
+++ b/gto-support-api/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     compile project(':gto-support-core')
+    compile project(':gto-support-api-base')
 
     compile 'com.google.guava:guava:18.0'
     compile 'me.thekey.android:thekey-api:1.1.1'

--- a/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractApi.java
+++ b/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractApi.java
@@ -15,7 +15,6 @@ import org.ccci.gto.android.common.api.AbstractApi.ExecutionContext;
 import org.ccci.gto.android.common.api.AbstractApi.Request;
 import org.ccci.gto.android.common.api.AbstractApi.Request.MediaType;
 import org.ccci.gto.android.common.api.AbstractApi.Request.Parameter;
-import org.ccci.gto.android.common.api.AbstractApi.Session;
 import org.ccci.gto.android.common.util.IOUtils;
 import org.ccci.gto.android.common.util.UriUtils;
 import org.json.JSONArray;
@@ -37,7 +36,6 @@ import java.util.UUID;
 
 public abstract class AbstractApi<R extends Request<C, S>, C extends ExecutionContext<S>, S extends Session> {
     private static final int DEFAULT_ATTEMPTS = 3;
-    protected static final String PREF_SESSION_BASE_NAME = "session";
 
     protected final Object LOCK_SESSION = new Object();
 
@@ -398,65 +396,6 @@ public abstract class AbstractApi<R extends Request<C, S>, C extends ExecutionCo
     }
 
     /* END request lifecycle events */
-
-    /**
-     * Object representing an individual session for this API. Can be extended to track additional session data.
-     */
-    public static class Session {
-        @NonNull
-        private final String baseAttrName;
-
-        @Nullable
-        public final String id;
-
-        protected Session(@Nullable final String id) {
-            this(id, PREF_SESSION_BASE_NAME);
-        }
-
-        protected Session(@Nullable final String id, @Nullable final String baseAttrName) {
-            this.baseAttrName = baseAttrName != null ? baseAttrName : PREF_SESSION_BASE_NAME;
-            this.id = id;
-        }
-
-        protected Session(@NonNull final SharedPreferences prefs) {
-            this(prefs, null);
-        }
-
-        protected Session(@NonNull final SharedPreferences prefs, @Nullable final String baseAttrName) {
-            this.baseAttrName = baseAttrName != null ? baseAttrName : PREF_SESSION_BASE_NAME;
-            this.id = prefs.getString(getPrefAttrName("id"), null);
-        }
-
-        protected boolean isValid() {
-            return this.id != null;
-        }
-
-        @NonNull
-        protected final String getPrefAttrName(@NonNull final String type) {
-            return baseAttrName + "." + type;
-        }
-
-        protected void save(@NonNull final SharedPreferences.Editor prefs) {
-            prefs.putString(getPrefAttrName("id"), this.id);
-        }
-
-        protected void delete(@NonNull final SharedPreferences.Editor prefs) {
-            prefs.remove(getPrefAttrName("id"));
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Session that = (Session) o;
-            return !(id != null ? !id.equals(that.id) : that.id != null);
-        }
-    }
 
     /**
      * Object tracking the execution context data for processing a request.

--- a/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractGtoSmxApi.java
+++ b/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractGtoSmxApi.java
@@ -12,7 +12,6 @@ import android.support.annotation.WorkerThread;
 import org.ccci.gto.android.common.api.AbstractApi.Request.MediaType;
 import org.ccci.gto.android.common.api.AbstractGtoSmxApi.Request;
 import org.ccci.gto.android.common.api.AbstractTheKeyApi.ExecutionContext;
-import org.ccci.gto.android.common.api.AbstractTheKeyApi.Session;
 import org.ccci.gto.android.common.util.IOUtils;
 
 import java.io.IOException;
@@ -23,7 +22,7 @@ import me.thekey.android.TheKey;
 import me.thekey.android.TheKeySocketException;
 
 public abstract class AbstractGtoSmxApi
-        extends AbstractTheKeyApi<Request, ExecutionContext<Session>, Session> {
+        extends AbstractTheKeyApi<Request, ExecutionContext<TheKeySession>, TheKeySession> {
     private static final String PARAM_APPVERSION = "_appVersion";
 
     private final String appVersion;
@@ -80,14 +79,14 @@ public abstract class AbstractGtoSmxApi
 
     @Nullable
     @Override
-    protected final Session loadSession(@NonNull final SharedPreferences prefs, @NonNull final Request request) {
+    protected final TheKeySession loadSession(@NonNull final SharedPreferences prefs, @NonNull final Request request) {
         assert request.context != null;
-        return new Session(prefs, request.context.guid);
+        return new TheKeySession(prefs, request.context.guid);
     }
 
     @Nullable
     @Override
-    protected Session establishSession(@NonNull final Request request) throws ApiException {
+    protected TheKeySession establishSession(@NonNull final Request request) throws ApiException {
         assert request.context != null;
 
         // short-circuit if we don't have a guid to establish a session for
@@ -125,7 +124,7 @@ public abstract class AbstractGtoSmxApi
         }
 
         // create & return a session object
-        return sessionId != null ? new Session(sessionId, request.context.guid) : null;
+        return sessionId != null ? new TheKeySession(sessionId, request.context.guid) : null;
     }
 
     @Override
@@ -274,7 +273,7 @@ public abstract class AbstractGtoSmxApi
     /**
      * class that represents a request being sent to the api
      */
-    protected static class Request extends AbstractTheKeyApi.Request<ExecutionContext<Session>, Session> {
+    protected static class Request extends AbstractTheKeyApi.Request<ExecutionContext<TheKeySession>, TheKeySession> {
         public Request(@NonNull final String path) {
             super(path);
         }

--- a/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractTheKeyApi.java
+++ b/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractTheKeyApi.java
@@ -180,7 +180,7 @@ public abstract class AbstractTheKeyApi<R extends Request<C, S>, C extends Execu
         return null;
     }
 
-    public static class Session extends AbstractApi.Session {
+    public static class Session extends org.ccci.gto.android.common.api.Session {
         @Nullable
         private final String guid;
 
@@ -204,7 +204,7 @@ public abstract class AbstractTheKeyApi<R extends Request<C, S>, C extends Execu
         }
 
         @Override
-        protected boolean isValid() {
+        public boolean isValid() {
             return super.isValid() && this.guid != null;
         }
 

--- a/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractTheKeyApi.java
+++ b/gto-support-api/src/main/java/org/ccci/gto/android/common/api/AbstractTheKeyApi.java
@@ -12,16 +12,14 @@ import android.support.annotation.Nullable;
 
 import org.ccci.gto.android.common.api.AbstractTheKeyApi.ExecutionContext;
 import org.ccci.gto.android.common.api.AbstractTheKeyApi.Request;
-import org.ccci.gto.android.common.api.AbstractTheKeyApi.Session;
 import org.ccci.gto.android.common.util.HttpHeaderUtils;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Locale;
 
 import me.thekey.android.TheKey;
 
-public abstract class AbstractTheKeyApi<R extends Request<C, S>, C extends ExecutionContext<S>, S extends Session>
+public abstract class AbstractTheKeyApi<R extends Request<C, S>, C extends ExecutionContext<S>, S extends TheKeySession>
         extends AbstractApi<R, C, S> {
     private static final String PREF_CACHED_SERVICE = "service";
 
@@ -180,54 +178,13 @@ public abstract class AbstractTheKeyApi<R extends Request<C, S>, C extends Execu
         return null;
     }
 
-    public static class Session extends org.ccci.gto.android.common.api.Session {
-        @Nullable
-        private final String guid;
-
-        protected Session(@Nullable final String id, @Nullable final String guid) {
-            this(id, guid, PREF_SESSION_BASE_NAME);
-        }
-
-        protected Session(@Nullable final String id, @Nullable final String guid, @NonNull final String baseAttrName) {
-            super(id, (guid != null ? guid.toUpperCase(Locale.US) + "." : "") + baseAttrName);
-            this.guid = guid != null ? guid.toUpperCase(Locale.US) : null;
-        }
-
-        protected Session(@NonNull final SharedPreferences prefs, @Nullable final String guid) {
-            this(prefs, guid, PREF_SESSION_BASE_NAME);
-        }
-
-        protected Session(@NonNull final SharedPreferences prefs, @Nullable final String guid,
-                          @NonNull final String baseAttrName) {
-            super(prefs, (guid != null ? guid.toUpperCase(Locale.US) + "." : "") + baseAttrName);
-            this.guid = guid != null ? guid.toUpperCase(Locale.US) : null;
-        }
-
-        @Override
-        public boolean isValid() {
-            return super.isValid() && this.guid != null;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Session that = (Session) o;
-            return super.equals(o) && !(guid != null ? !guid.equals(that.guid) : that.guid != null);
-        }
-    }
-
-    public static class ExecutionContext<S extends Session> extends AbstractApi.ExecutionContext<S> {
+    public static class ExecutionContext<S extends TheKeySession> extends AbstractApi.ExecutionContext<S> {
         @Nullable
         public String guid = null;
     }
 
-    public static class Request<C extends ExecutionContext<S>, S extends Session> extends AbstractApi.Request<C, S> {
+    public static class Request<C extends ExecutionContext<S>, S extends TheKeySession>
+            extends AbstractApi.Request<C, S> {
         public Request(@NonNull final String path) {
             super(path);
             // use sessions by default for The Key protected APIs

--- a/gto-support-core/build.gradle
+++ b/gto-support-core/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 android {
     defaultConfig {
         consumerProguardFiles 'proguard-consumer.pro'

--- a/gto-support-core/src/main/java/org/ccci/gto/android/common/util/SharedPreferencesCompat.java
+++ b/gto-support-core/src/main/java/org/ccci/gto/android/common/util/SharedPreferencesCompat.java
@@ -1,0 +1,40 @@
+package org.ccci.gto.android.common.util;
+
+import android.annotation.TargetApi;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.support.annotation.NonNull;
+
+public class SharedPreferencesCompat {
+    private static final Compat COMPAT;
+    static {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
+            COMPAT = new FroyoCompat();
+        } else {
+            COMPAT = new GingerbreadCompat();
+        }
+    }
+
+    public static void apply(@NonNull final SharedPreferences.Editor prefs) {
+        COMPAT.apply(prefs);
+    }
+
+    private interface Compat {
+        void apply(@NonNull SharedPreferences.Editor prefs);
+    }
+
+    private static class FroyoCompat implements Compat {
+        @Override
+        public void apply(@NonNull final SharedPreferences.Editor prefs) {
+            prefs.commit();
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+    private static class GingerbreadCompat extends FroyoCompat {
+        @Override
+        public void apply(@NonNull final SharedPreferences.Editor prefs) {
+            prefs.apply();
+        }
+    }
+}

--- a/gto-support-db/build.gradle
+++ b/gto-support-db/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile project(':gto-support-core')
 

--- a/gto-support-newrelic/build.gradle
+++ b/gto-support-newrelic/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile 'com.newrelic.agent.android:android-agent:4.265.0'
 }

--- a/gto-support-picasso/build.gradle
+++ b/gto-support-picasso/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile project(':gto-support-core')
 

--- a/gto-support-recyclerview/build.gradle
+++ b/gto-support-recyclerview/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.android.library'
-
 dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':gto-support-api', ':gto-support-core', ':gto-support-db', ':gto-support-newrelic', ':gto-support-picasso', ':gto-support-recyclerview'
+include ':gto-support-api-base', ':gto-support-api', ':gto-support-core', ':gto-support-db', ':gto-support-newrelic', ':gto-support-picasso', ':gto-support-recyclerview'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-include ':gto-support-api-base', ':gto-support-api', ':gto-support-core', ':gto-support-db', ':gto-support-newrelic', ':gto-support-picasso', ':gto-support-recyclerview'
+include ':gto-support-api-base', ':gto-support-api-okhttp3', ':gto-support-api', ':gto-support-core',
+        ':gto-support-db', ':gto-support-newrelic', ':gto-support-picasso', ':gto-support-recyclerview'


### PR DESCRIPTION
This is based around the pre-existing session support for the native `HttpURLConnection` API.

The concept is that there is a `SessionInterceptor` that gets applied to all OkHttp3 network requests. The basic flow is:

1. Intercept a network request before it is sent
2. load a current session from preferences
3. if no valid current session exists, call out to external code to establish a new session
4. Attach the session to the request
5. proceed with executing the request
6. check the response to see if our session was invalid or not
7. if the session was invalid, delete the original loaded session
8. return the response